### PR TITLE
Replaced md5 hash with stamps in CMake

### DIFF
--- a/opentera_webrtc_demos/CMakeLists.txt
+++ b/opentera_webrtc_demos/CMakeLists.txt
@@ -209,16 +209,18 @@ include_directories(
 # catkin_add_nosetests(test)
 
 add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/node_modules.md5
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/node_modules.stamp
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/opentera-webrtc-teleop-frontend/teleop-vue/package.json
     COMMAND /usr/bin/env npm install
-    COMMAND tar c ${CMAKE_CURRENT_SOURCE_DIR}/opentera-webrtc-teleop-frontend/teleop-vue/node_modules 2> /dev/null | md5sum > ${CMAKE_CURRENT_BINARY_DIR}/node_modules.md5
+    COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/node_modules.stamp
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/opentera-webrtc-teleop-frontend/teleop-vue
+    VERBATIM
 )
 
 add_custom_target(
     opentera_werbrtc_teleop_frontend-install ALL
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/node_modules.md5
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/node_modules.stamp
+    VERBATIM
 )
 
 file(
@@ -231,16 +233,18 @@ file(
 )
 
 add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dist.md5
-    DEPENDS ${FRONTEND_FILES} ${CMAKE_CURRENT_BINARY_DIR}/node_modules.md5 opentera_werbrtc_teleop_frontend-install
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dist.stamp
+    DEPENDS ${FRONTEND_FILES} ${CMAKE_CURRENT_BINARY_DIR}/node_modules.stamp opentera_werbrtc_teleop_frontend-install
     COMMAND /usr/bin/env npm run build
-    COMMAND tar c ${CMAKE_CURRENT_SOURCE_DIR}/opentera-webrtc-teleop-frontend/teleop-vue/dist 2> /dev/null | md5sum > ${CMAKE_CURRENT_BINARY_DIR}/dist.md5
+    COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/dist.stamp
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/opentera-webrtc-teleop-frontend/teleop-vue
+    VERBATIM
 )
 
 add_custom_target(
     opentera_werbrtc_teleop_frontend-build ALL
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/dist.md5
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/dist.stamp
+    VERBATIM
 )
 
 #######################
@@ -255,4 +259,3 @@ endfunction()
 
 assert_program_installed("npm")
 assert_program_installed("tar")
-assert_program_installed("md5sum")

--- a/opentera_webrtc_demos/CMakeLists.txt
+++ b/opentera_webrtc_demos/CMakeLists.txt
@@ -211,7 +211,7 @@ include_directories(
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/node_modules.stamp
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/opentera-webrtc-teleop-frontend/teleop-vue/package.json
-    COMMAND /usr/bin/env npm install
+    COMMAND npm install
     COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/node_modules.stamp
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/opentera-webrtc-teleop-frontend/teleop-vue
     VERBATIM
@@ -235,7 +235,7 @@ file(
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dist.stamp
     DEPENDS ${FRONTEND_FILES} ${CMAKE_CURRENT_BINARY_DIR}/node_modules.stamp opentera_werbrtc_teleop_frontend-install
-    COMMAND /usr/bin/env npm run build
+    COMMAND npm run build
     COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/dist.stamp
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/opentera-webrtc-teleop-frontend/teleop-vue
     VERBATIM
@@ -258,4 +258,3 @@ function(assert_program_installed PROGRAM)
 endfunction()
 
 assert_program_installed("npm")
-assert_program_installed("tar")


### PR DESCRIPTION
The hash was not used, only the file timestamp.
Consistent with changed done in opentera-webrtc to ease usage on Mac, where md5sum is no installed by default