### PR TITLE
Correction of visual bugs in the robot gui

### DIFF
--- a/opentera_webrtc_robot_gui/src/LocalCameraWindow.cpp
+++ b/opentera_webrtc_robot_gui/src/LocalCameraWindow.cpp
@@ -81,26 +81,28 @@ void LocalCameraWindow::mouseMoveEvent(QMouseEvent* event)
 QPoint LocalCameraWindow::adjustPositionToBorders(QPoint pos)
 {
     QRect mainWindowRect = m_parent->getCameraSpace();
-    if (pos.x() < mainWindowRect.left())
+    if (mainWindowRect.right() - width() >= 0 && mainWindowRect.bottom() - height() >= 0)
     {
-        pos.setX(mainWindowRect.left());
-    }
-    else if (pos.x() > mainWindowRect.right() - width())
-    {
-        pos.setX(mainWindowRect.right() - width());
-    }
+        if (pos.x() < mainWindowRect.left())
+        {
+            pos.setX(mainWindowRect.left());
+        }
+        else if (pos.x() > mainWindowRect.right() - width())
+        {
+            pos.setX(mainWindowRect.right() - width());
+        }
 
-    if (pos.y() < mainWindowRect.top())
-    {
-        pos.setY(mainWindowRect.top());
-    }
-    else if (pos.y() > mainWindowRect.bottom() - height())
-    {
-        pos.setY(mainWindowRect.bottom() - height());
-    }
+        if (pos.y() < mainWindowRect.top())
+        {
+            pos.setY(mainWindowRect.top());
+        }
+        else if (pos.y() > mainWindowRect.bottom() - height())
+        {
+            pos.setY(mainWindowRect.bottom() - height());
+        }
 
-    setMaximumWidth(mainWindowRect.right() - pos.x());
-    setMaximumHeight(mainWindowRect.bottom() - pos.y());
-
+        setMaximumWidth(mainWindowRect.right() - pos.x());
+        setMaximumHeight(mainWindowRect.bottom() - pos.y());
+    }
     return pos;
 }

--- a/opentera_webrtc_robot_gui/src/MainWindow.h
+++ b/opentera_webrtc_robot_gui/src/MainWindow.h
@@ -181,6 +181,7 @@ private:
     void moveEvent(QMoveEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
 
+    bool m_inSession;
 
     // Main View
     Ui::MainWindow m_ui;


### PR DESCRIPTION
- Fiz a bug where the local camera window would shrink after a window resize.
- Fix a bug where the local camera window would go to the top left outside the main window.
- Fix a bug where the gui wouldn't remove the remote video stream widget and put back the local stream on stop session.

